### PR TITLE
harden deploy workflow: add permissions, pin actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,10 @@ on:
   push:
     branches:
       - master
+
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -14,7 +18,7 @@ jobs:
           submodules: recursive
 
       - name: Setup hugo
-        uses: peaceiris/actions-hugo@v3
+        uses: peaceiris/actions-hugo@75d2e84710de30f6ff7268e08f310b60ef14033f # v3.0.0
         with:
           hugo-version: "0.154.2"
 
@@ -22,7 +26,7 @@ jobs:
         run: hugo --minify --environment production
 
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         with:
           personal_token: ${{ secrets.DEPLOY_TOKEN }}
           external_repository: ru-nl/ru-nl.github.io


### PR DESCRIPTION
## Summary
- add `permissions: contents: read` (least privilege for GITHUB_TOKEN)
- pin `peaceiris/actions-hugo` to v3.0.0 SHA (`75d2e847`)
- pin `peaceiris/actions-gh-pages` to v4.0.0 SHA (`4f9cc660`) — this action receives `DEPLOY_TOKEN` PAT, making SHA pinning important for supply-chain protection

Context: https://www.stepsecurity.io/blog/hackerbot-claw-github-actions-exploitation