### PR TITLE
Remove .Site.Author usage from RSS template

### DIFF
--- a/layouts/rss.xml
+++ b/layouts/rss.xml
@@ -12,9 +12,7 @@
         <link>{{ .Permalink }}</link>
         <description>Recent content {{ if ne  .Title  .Site.Title }}{{ with .Title }}in {{.}} {{ end }}{{ end }}on {{ .Site.Title }}</description>
         <generator>Hugo -- gohugo.io</generator>{{ with .Site.LanguageCode }}
-        <language>{{.}}</language>{{end}}{{ with .Site.Author.email }}
-        <managingEditor>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Author.email }}
-        <webMaster>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
+        <language>{{.}}</language>{{end}}{{ with .Site.Copyright }}
         <copyright>{{.}}</copyright>{{end}}{{ if not .Date.IsZero }}
         <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
         {{ with .OutputFormats.Get "RSS" }}
@@ -30,7 +28,6 @@
             <turbo:source>{{ .Permalink }}</turbo:source>
             <turbo:topic>{{ .Title }}</turbo:topic>{{ if not .Date.IsZero}}
             <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>{{end}}
-            {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
             <guid>{{ .Permalink }}</guid>
             {{ if .Site.Params.rssFullContent }}
             <description>{{ .Content | htmlEscape }}</description>


### PR DESCRIPTION
Previously, layouts/rss.xml referenced .Site.Author, which was removed in newer Hugo; the build failed on anything past the pinned 0.154.2, blocking Hugo upgrades. No author is configured in config.json, so the managingEditor, webMaster and author elements always rendered empty.

After this change, the empty-rendering elements are gone and the site builds on both Hugo 0.154.2 (CI) and 0.163.3 (verified locally); the generated feed is unchanged.