### PR TITLE
Fix double-escaped HTML in RSS item descriptions

### DIFF
--- a/layouts/rss.xml
+++ b/layouts/rss.xml
@@ -33,7 +33,7 @@
             {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
             <guid>{{ .Permalink }}</guid>
             {{ if .Site.Params.rssFullContent }}
-            <description>{{ .Content | htmlEscape }}</description>
+            <description>{{ .Content | transform.XMLEscape | safeHTML }}</description>
             {{ else }}
             <description>{{ .Summary | html }}</description>
             {{ end }}


### PR DESCRIPTION
Previously, the item description passed .Content through htmlEscape and Go's html/template auto-escaping escaped it a second time, so the published feed contained &amp;amp;lt;p&amp;amp;gt; and feed readers displayed raw HTML tags as text.

After this change, the description uses transform.XMLEscape with safeHTML, escaping exactly once as Hugo's built-in RSS template does. Verified against a local build on Hugo 0.154.2: descriptions now come out single-escaped and the feed passes xmllint.