### PR TITLE
Build on pull requests, deploy only on push to master

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+  pull_request:
 
 permissions:
   contents: read
@@ -26,6 +27,7 @@ jobs:
         run: hugo --minify --environment production
 
       - name: Deploy
+        if: github.event_name == 'push'
         uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
         with:
           personal_token: ${{ secrets.DEPLOY_TOKEN }}


### PR DESCRIPTION
Previously, the CI workflow triggered only on push to master, so a pull request that broke the Hugo build was caught only after merge, when the deploy job failed. The README invites contributor PRs, so the build should verify them beforehand.

After this change, `pull_request` events run checkout, Hugo setup and build; the Deploy step is gated on `github.event_name == 'push'`, so it still runs only for pushes to master and never from a PR. Fork PRs have no access to `DEPLOY_TOKEN` regardless, and the trigger is plain `pull_request` (not `pull_request_target`) with workflow permissions kept at `contents: read`.

This PR is itself built by the new trigger, so a green check here confirms the build path works.