### PR TITLE
Drop dead Yandex Turbo markup from RSS feed

### DIFF
--- a/layouts/rss.xml
+++ b/layouts/rss.xml
@@ -1,55 +1,66 @@
-{{- $pctx := . -}}
-        {{- if .IsHome -}}{{ $pctx = .Site }}{{- end -}}
-        {{- $pages := $pctx.Pages -}}
-        {{- $limit := .Site.Config.Services.RSS.Limit -}}
-        {{- if ge $limit 1 -}}
-        {{- $pages = $pages | first $limit -}}
-        {{- end -}}
-        {{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
-<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:yandex="http://news.yandex.ru" xmlns:media="http://search.yahoo.com/mrss/" xmlns:turbo="http://turbo.yandex.ru">
-    <channel>
-        <title>{{ if eq  .Title  .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{.}} on {{ end }}{{ .Site.Title }}{{ end }}</title>
-        <link>{{ .Permalink }}</link>
-        <description>Recent content {{ if ne  .Title  .Site.Title }}{{ with .Title }}in {{.}} {{ end }}{{ end }}on {{ .Site.Title }}</description>
-        <generator>Hugo -- gohugo.io</generator>{{ with .Site.LanguageCode }}
-        <language>{{.}}</language>{{end}}{{ with .Site.Copyright }}
-        <copyright>{{.}}</copyright>{{end}}{{ if not .Date.IsZero }}
-        <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
-        {{ with .OutputFormats.Get "RSS" }}
-        {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
-        {{ end }}
-        {{ range $pages }}
-        <item turbo="true">
-            <title>{{ .Title }}</title>
-            <link>{{ .Permalink }}</link>
-            <media:rating scheme="urn:simple">nonadult</media:rating>
-            <category>Technology</category>
-            <category>Технологии</category>
-            <turbo:source>{{ .Permalink }}</turbo:source>
-            <turbo:topic>{{ .Title }}</turbo:topic>{{ if not .Date.IsZero}}
-            <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>{{end}}
-            <guid>{{ .Permalink }}</guid>
-            {{ if .Site.Params.rssFullContent }}
-            <description>{{ .Content | transform.XMLEscape | safeHTML }}</description>
-            {{ else }}
-            <description>{{ .Summary | html }}</description>
-            {{ end }}
-            <turbo:content>
-                {{- printf "<![CDATA[" | safeHTML }}
-            <header><h1>{{ .Title }}</h1></header>
-			{{ .Content }}
-        {{- printf "]]>" | safeHTML }}
-            </turbo:content>
-            {{- with .Resources.ByType "image" }}
-            {{- range . }}
-            {{- if not (in .MediaType "image/webp") }}
-            <enclosure url="{{ .Permalink }}" length="{{ len .Content }}" type="{{ .MediaType }}"/>
-            {{- end }}
-            {{- end }}
-            {{- else }}
-            <enclosure url="{{ .Site.Params.image | absURL }}" length="438598" type="image/jpg"/>
-            {{- end }}
-        </item>
-        {{ end }}
-    </channel>
+{{- $authorEmail := "" }}
+{{- with site.Params.author }}
+  {{- if reflect.IsMap . }}
+    {{- with .email }}
+      {{- $authorEmail = . }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
+{{- $authorName := "" }}
+{{- with site.Params.author }}
+  {{- if reflect.IsMap . }}
+    {{- with .name }}
+      {{- $authorName = . }}
+    {{- end }}
+  {{- else }}
+    {{- $authorName = . }}
+  {{- end }}
+{{- end }}
+
+{{- $pctx := . }}
+{{- if .IsHome }}{{ $pctx = .Site }}{{ end }}
+{{- $pages := $pctx.Pages }}
+{{- $limit := .Site.Config.Services.RSS.Limit }}
+{{- if ge $limit 1 }}
+{{- $pages = $pages | first $limit }}
+{{- end }}
+{{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/">
+  <channel>
+    <title>{{ if eq .Title .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} on {{ end }}{{ .Site.Title }}{{ end }}</title>
+    <link>{{ .Permalink }}</link>
+    <description>Recent content {{ if ne .Title .Site.Title }}{{ with .Title }}in {{ . }} {{ end }}{{ end }}on {{ .Site.Title }}</description>
+    <generator>Hugo</generator>
+    <language>{{ site.Language.LanguageCode }}</language>{{ with $authorEmail }}
+    <managingEditor>{{ . }}{{ with $authorName }} ({{ . }}){{ end }}</managingEditor>{{ end }}{{ with $authorEmail }}
+    <webMaster>{{ . }}{{ with $authorName }} ({{ . }}){{ end }}</webMaster>{{ end }}{{ with .Site.Copyright }}
+    <copyright>{{ . }}</copyright>{{ end }}{{ if not .Date.IsZero }}
+    <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
+    {{- with .OutputFormats.Get "RSS" }}
+    {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
+    {{- end }}
+    {{- range $pages }}
+    <item>
+      <title>{{ .Title }}</title>
+      <link>{{ .Permalink }}</link>
+      <media:rating scheme="urn:simple">nonadult</media:rating>{{ if not .Date.IsZero }}
+      <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>{{ end }}{{ with $authorEmail }}
+      <author>{{ . }}{{ with $authorName }} ({{ . }}){{ end }}</author>{{ end }}
+      <guid>{{ .Permalink }}</guid>
+      {{ if .Site.Params.rssFullContent }}
+      <description>{{ .Content | transform.XMLEscape | safeHTML }}</description>
+      {{ else }}
+      <description>{{ .Summary | transform.XMLEscape | safeHTML }}</description>
+      {{ end }}
+      {{- with .Resources.ByType "image" }}
+        {{- range . }}
+          {{- if not (in .MediaType "image/webp") }}
+      <enclosure url="{{ .Permalink }}" length="{{ len .Content }}" type="{{ .MediaType }}"/>
+          {{- end }}
+        {{- end }}
+      {{- end }}
+    </item>
+    {{- end }}
+  </channel>
 </rss>


### PR DESCRIPTION
Previously, `layouts/rss.xml` was built around Yandex Turbo (the `yandex`/`turbo` namespaces, `turbo:*` elements and a duplicated `turbo:content` CDATA block). Yandex Turbo was discontinued, so this markup is dead weight that also emitted every page's content twice in the feed.

This reworks the template after the `paskal/blog` `rss.xml`:
- remove the Yandex Turbo namespaces and all `turbo:*` elements
- remove the stray `<category>Technology</category>` tags
- drop the fallback `<enclosure>`, which pointed every item at the homepage with a hard-coded length, since no `params.image` is set
- keep the optional author wired to the modern `site.Params.author` (unset here, so `managingEditor`/`webMaster`/`author` stay omitted)
- use `site.Language.LanguageCode` (still `ru-ru`) instead of the deprecated `.Site.LanguageCode`

Follows on from #22 (dropped the removed `.Site.Author`) and #23 (fixed description double-escaping), both merged; this finishes the RSS cleanup. Feed membership is unchanged (14 items); verified building on Hugo 0.154.2 and 0.163.3 and with xmllint.